### PR TITLE
fixes for issues #10 and #11

### DIFF
--- a/src/tech/v2/datatype/binary_op.clj
+++ b/src/tech/v2/datatype/binary_op.clj
@@ -419,6 +419,11 @@
        (let [{datatype# :datatype
               unchecked?# :unchecked?} options#
              datatype# (or datatype# :int64)]
+         (when-not (#{:int8 :int16 :int32 :int64 :object}
+                    datatype#)
+           (throw (ex-info (format "Operator only supports integer datatypes, %s"
+                                   datatype#)
+                           {})))
          (-> (case (casting/safe-flatten datatype#)
                :int8 (make-binary-op ~opname :int8 (byte ~op-code))
                :int16 (make-binary-op ~opname :int16 (short ~op-code))

--- a/src/tech/v2/datatype/functional.clj
+++ b/src/tech/v2/datatype/functional.clj
@@ -74,7 +74,10 @@
                      kurtosis-population
                      pearsons-correlation
                      spearmans-correlation
-                     kendalls-correlation)
+                     kendalls-correlation
+                     percentile
+                     quartiles
+                     quartile-outlier-fn)
 
 
 (impl/export-symbols tech.v2.datatype.rolling

--- a/src/tech/v2/datatype/statistics.clj
+++ b/src/tech/v2/datatype/statistics.clj
@@ -2,16 +2,25 @@
   (:require [tech.v2.datatype.base :as dtype-base]
             [tech.v2.datatype.typecast :as typecast]
             [tech.v2.datatype.protocols :as dtype-proto]
+            [tech.v2.datatype.boolean-op :as boolean-op]
             [tech.v2.datatype.array]
             [kixi.stats.core :as kixi])
   (:import [org.apache.commons.math3.stat.correlation
-            KendallsCorrelation PearsonsCorrelation SpearmansCorrelation]))
+            KendallsCorrelation PearsonsCorrelation SpearmansCorrelation]
+           [org.apache.commons.math3.stat.descriptive DescriptiveStatistics]))
 
 
 (defn- kixi-apply
   [kixi-fn item]
   (transduce identity kixi-fn (or (dtype-proto/as-reader item)
                                   (dtype-proto/as-iterable item))))
+
+(defn- ->double-array
+  ^doubles [item]
+  (if (instance? (Class/forName "[D") item)
+    item
+    (dtype-base/make-container :java-array :float64 item)))
+
 
 
 (defn mean
@@ -102,3 +111,38 @@
   [lhs rhs]
   (-> (KendallsCorrelation.)
       (.correlation (->doubles lhs) (->doubles rhs))))
+
+
+(defn percentile
+  "Get the nth percentile.  Percent ranges from 0-100."
+  [item percent]
+  (-> (DescriptiveStatistics. (->double-array item))
+      (.getPercentile (double percent))))
+
+
+(defn quartiles
+  "return [min, 25 50 75 max] of item"
+  [item]
+  (let [stats (DescriptiveStatistics. (->double-array item))]
+    [(.getMin stats)
+     (.getPercentile stats 25.0)
+     (.getPercentile stats 50.0)
+     (.getPercentile stats 75.0)
+     (.getMax stats)]))
+
+
+(defn quartile-outlier-fn
+  "Create a function that, given floating point data, will return true or false
+  if that data is an outlier.  Default range mult is 1.5:
+  (or (< val (- q1 (* range-mult iqr)))
+      (> val (+ q3 (* range-mult iqr)))"
+  [item & [range-mult]]
+  (let [[_ q1 _ q3 _] (quartiles item)
+        q1 (double q1)
+        q3 (double q3)
+        iqr (- q3 q1)
+        range-mult (double (or range-mult 1.5))]
+    (boolean-op/make-boolean-unary-op
+     :float64
+     (or (< x (- q1 (* range-mult iqr)))
+         (> x (+ q3 (* range-mult iqr)))))))

--- a/test/tech/v2/datatype_test.clj
+++ b/test/tech/v2/datatype_test.clj
@@ -272,3 +272,22 @@
            (->> (dfn/eq test-floats nan-floats)
                 (dfn/argfilter identity)
                 vec)))))
+
+
+(deftest round-and-friends
+  (is (= [2.0 3.0 4.0 5.0]
+         (vec (dfn/round [2.2 2.8 3.5 4.6]))))
+  (is (= [2.0 2.0 3.0 4.0]
+         (vec (dfn/floor [2.2 2.8 3.5 4.6]))))
+  (is (= [3.0 3.0 4.0 5.0]
+         (vec (dfn/ceil [2.2 2.8 3.5 4.6]))))
+  (is (= [2.2 2.8 3.5 4.6]
+         (vec (dfn/abs [2.2 2.8 3.5 4.6]))))
+  (is (= [1 4 9 16]
+         (vec (dfn/sq (byte-array [1 2 3 4])))))
+  (is (dfn/equals [0.381 0.540 0.675 0.785]
+                  (dfn/atan2 [2 3 4 5] 5)
+                  0.001))
+  (is (thrown? Throwable (dfn/rem (double-array [1 2 3 4] 2))))
+  (is (= [1 0 1 0]
+         (dfn/rem [1 2 3 4] 2))))


### PR DESCRIPTION
The unary and binary operators should all work on persistent vectors.  In that case, in general they should cast to double and apply their operations.

Then, we need simple fast outlier detection so implemented that using the descriptive statistics of apache commons-math.