### PR TITLE
Deftype upgrade

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src"]
  :deps {org.clojure/clojure              {:mvn/version "1.10.1"}
         techascent/tech.jna              {:mvn/version "3.18"}
-        techascent/tech.parallel         {:mvn/version "1.7"}
+        techascent/tech.parallel         {:mvn/version "1.8"}
         it.unimi.dsi/fastutil            {:mvn/version "8.2.1"}
         kixi/stats                       {:mvn/version "0.5.0"}
         org.apache.commons/commons-math3 {:mvn/version "3.6.1"}}}

--- a/src/tech/v2/datatype/list.clj
+++ b/src/tech/v2/datatype/list.clj
@@ -35,7 +35,8 @@
             LongReader LongWriter LongMutable
             FloatReader FloatWriter FloatMutable
             DoubleReader DoubleWriter DoubleMutable
-            BooleanReader BooleanWriter BooleanMutable]))
+            BooleanReader BooleanWriter BooleanMutable]
+           [tech.v2.datatype.typed_buffer TypedBuffer]))
 
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
@@ -417,7 +418,7 @@
                     (-> (typed-buffer/make-typed-buffer
                          datatype
                          elem-count-or-seq options)
-                        :backing-store
+                        (#(.backing-store ^TypedBuffer %))
                         dtype-proto/->list-backing-store)
                     (let [list-data (make-list (casting/host-flatten datatype) 0)]
                       (iterable-to-list/iterable->list elem-count-or-seq

--- a/src/tech/v2/datatype/list.clj
+++ b/src/tech/v2/datatype/list.clj
@@ -421,10 +421,15 @@
                         (#(.backing-store ^TypedBuffer %))
                         dtype-proto/->list-backing-store)
                     (let [list-data (make-list (casting/host-flatten datatype) 0)]
-                      (iterable-to-list/iterable->list elem-count-or-seq
-                                                       list-data
-                                                       {:unchecked? (:unchecked? options)
-                                                        :datatype datatype})))]
+                      (-> (dtype-proto/->iterable elem-count-or-seq
+                                                  {:datatype
+                                                   (casting/safe-flatten datatype)
+                                                   :unchecked?
+                                                   (:unchecked? options)})
+                          (iterable-to-list/iterable->list
+                           list-data
+                           {:unchecked? true
+                            :datatype datatype}))))]
     (if host-datatype?
       typed-buf
       (typed-buffer/set-datatype typed-buf datatype))))

--- a/src/tech/v2/datatype/mutable/iterable_to_list.clj
+++ b/src/tech/v2/datatype/mutable/iterable_to_list.clj
@@ -13,7 +13,8 @@
                              output# (or output#
                                          (dtype-proto/make-container
                                           :list ~dtype 0))
-                             mutable# (typecast/datatype->mutable ~dtype output#)]
+                             mutable# (typecast/datatype->mutable ~dtype output#
+                                                                  unchecked?#)]
                          (while (.hasNext iter#)
                            (.append mutable# (typecast/datatype->iter-next-fn
                                               ~dtype iter#)))

--- a/src/tech/v2/datatype/pprint.clj
+++ b/src/tech/v2/datatype/pprint.clj
@@ -1,0 +1,18 @@
+(ns tech.v2.datatype.pprint)
+
+
+;; pretty-printing utilities for matrices
+(def ^:dynamic *number-format* "%.3f")
+
+
+(defn format-num [x]
+  (if (integer? x)
+    (str x)
+    (format *number-format* (double x))))
+
+
+(defn format-object
+  [x]
+  (if (number? x)
+    (format-num x)
+    (str x)))

--- a/src/tech/v2/datatype/sparse/sparse_base.clj
+++ b/src/tech/v2/datatype/sparse/sparse_base.clj
@@ -53,9 +53,11 @@
         ;;cache the filter, we will need ecount anyway
         filter-iter (->> (sparse-filter-fn data-seq sparse-value)
                          (dtype-base/make-container :list :boolean))
-        indexes (->> (masked-iterable/iterable-mask {:datatype :int32} filter-iter (range))
+        indexes (->> (masked-iterable/iterable-mask {:datatype :int32}
+                                                    filter-iter (range))
                      (dtype-base/make-container :list :int32))
-        data (->> (masked-iterable/iterable-mask {:datatype datatype} filter-iter data-seq)
+        data (->> (masked-iterable/iterable-mask {:datatype datatype}
+                                                 filter-iter data-seq)
                   (dtype-base/make-container :list datatype))]
     (make-sparse-reader indexes data (dtype-base/ecount filter-iter)
                         :datatype datatype

--- a/src/tech/v2/tensor/impl.clj
+++ b/src/tech/v2/tensor/impl.clj
@@ -25,7 +25,8 @@
               [tech.jna :as jna])
     (:import [tech.v2.datatype
               IndexingSystem$Forward
-              IndexingSystem$Backward]
+              IndexingSystem$Backward
+              ObjectReader]
              [com.sun.jna Pointer]
              [java.io Writer]))
 
@@ -107,6 +108,7 @@
                 (assoc item
                        :global-dims
                        (global-address->global-shape global-index strides)))))))
+
 
 
 (defmacro make-tensor-reader
@@ -259,221 +261,219 @@
          (dims/ecount dimensions))))))
 
 
-(declare slice)
+(declare slice construct-tensor)
+
+(deftype Tensor [buffer dimensions buffer-type]
+   dtype-proto/PDatatype
+   (get-datatype [item] (dtype-base/get-datatype buffer))
+
+
+   dtype-proto/PCountable
+   (ecount [item] (dims/ecount dimensions))
+
+
+   dtype-proto/PShape
+   (shape [m] (dims/shape dimensions))
+
+
+   dtype-proto/PPrototype
+   (from-prototype [m datatype shape]
+     (construct-tensor
+      (dtype-proto/from-prototype buffer datatype shape)
+      dimensions))
+
+
+   dtype-proto/PToNioBuffer
+   (convertible-to-nio-buffer? [item]
+     (dtype-proto/nio-convertible? buffer))
+   (->buffer-backing-store [item]
+     (when (simple-dimensions? dimensions)
+       (typecast/as-nio-buffer buffer)))
+
+
+   dtype-proto/PToList
+   (convertible-to-fastutil-list? [item]
+     (dtype-proto/list-convertible? buffer))
+   (->list-backing-store [item]
+     (when (simple-dimensions? dimensions)
+       (typecast/as-list buffer)))
+
+
+   jna/PToPtr
+   (is-jna-ptr-convertible? [item]
+     (jna/ptr-convertible? buffer))
+   (->ptr-backing-store [item]
+     (when (simple-dimensions? dimensions)
+       (jna/as-ptr buffer)))
+
+
+   dtype-proto/PToBufferDesc
+   (convertible-to-buffer-desc? [item]
+     (and (jna/ptr-convertible? buffer)
+          (dims-suitable-for-desc? dimensions)))
+   (->buffer-descriptor [item]
+     {:ptr (jna/as-ptr buffer)
+      :datatype (dtype/get-datatype buffer)
+      :shape (dtype/shape item)
+      :strides (mapv (partial * (casting/numeric-byte-width
+                                 (dtype/get-datatype buffer)))
+                     (:strides dimensions))})
+
+
+   dtype-proto/PToArray
+   (->sub-array [item]
+     (when (and (simple-dimensions? dimensions)
+                (satisfies? dtype-proto/PToArray buffer))
+       (dtype-proto/->sub-array buffer)))
+
+   (->array-copy [item]
+     (if (and (simple-dimensions? dimensions)
+              (satisfies? dtype-proto/PToArray buffer))
+       (dtype-proto/->array-copy buffer)
+       (dtype-proto/->array-copy (dtype-proto/->writer item {}))))
+
+
+   dtype-proto/PBuffer
+   (sub-buffer [item offset length]
+     (if (simple-dimensions? dimensions)
+       (dtype-proto/sub-buffer buffer offset length)
+       (throw (ex-info "Cannot sub-buffer tensors with complex addressing" {}))))
+
+
+   dtype-proto/PSetConstant
+   (set-constant! [item offset value elem-count]
+     (if (simple-dimensions? dimensions)
+       (dtype-proto/set-constant! buffer offset value elem-count)
+       (if (= :sparse (dtype/buffer-type buffer))
+         (dtype-proto/write-indexes! buffer
+                                     (-> (dimensions->index-reader dimensions)
+                                         (dtype-base/sub-buffer offset elem-count))
+                                     (sparse-reader/const-sparse-reader
+                                      value
+                                      (dtype-base/get-datatype item)
+                                      elem-count)
+                                     {:indexes-in-order?
+                                      (dims/access-increasing? dimensions)})
+         (dtype-proto/set-constant! (indexed-writer/make-indexed-writer
+                                     (dimensions->index-reader dimensions)
+                                     buffer
+                                     {})
+                                    offset value elem-count))))
+
+
+   dtype-proto/PWriteIndexes
+   (write-indexes! [item indexes values options]
+     (if (simple-dimensions? dimensions)
+       (dtype-proto/write-indexes! buffer indexes values options)
+       (dtype-proto/write-indexes! buffer (indexed-reader/make-indexed-reader
+                                           indexes
+                                           (dimensions->index-reader dimensions)
+                                           {:datatype :int32})
+                                   values options)))
+
+
+   dtype-proto/PToReader
+   (convertible-to-reader? [item] (dtype-proto/convertible-to-reader? buffer))
+   (->reader [item options]
+     (let [data-reader (dtype-proto/->reader buffer options)]
+       (if (simple-dimensions? dimensions)
+         data-reader
+         (tens-proto/->tensor-reader item options))))
+
+
+   dtype-proto/PToWriter
+   (convertible-to-writer? [item] (dtype-proto/convertible-to-writer? buffer))
+   (->writer [item options]
+     (let [data-writer (dtype-proto/->writer buffer options)]
+       (if (simple-dimensions? dimensions)
+         data-writer
+         (indexed-writer/make-indexed-writer (dimensions->index-reader dimensions)
+                                             data-writer
+                                             options))))
+
+
+   dtype-proto/PBufferType
+   (buffer-type [item]
+     (or buffer-type (dtype-proto/buffer-type buffer)))
+
+
+   ;;Tensors implement only a small subset of the sparse protocols
+   ;;For the full set, calling sparse-proto/as-sparse is your only option.
+   sparse-proto/PSparse
+   (index-seq [item]
+     (sparse-reader->index-seq (sparse-proto/as-sparse item) (dtype/shape item)))
+   (sparse-value [item]
+     (when-let [sparse-data (sparse-proto/as-sparse buffer)]
+       (sparse-proto/sparse-value buffer)))
+
+
+   sparse-proto/PToSparse
+   (convertible-to-sparse? [item]
+     (sparse-proto/sparse-convertible? buffer))
+   (->sparse [item]
+     (if (simple-dimensions? dimensions)
+       (sparse-proto/as-sparse buffer)
+       (make-tensor-base-sparse-reader buffer dimensions)))
+
+   tens-proto/PTensor
+   (is-tensor? [item] true)
+   (dimensions [item] dimensions)
+   (buffer [item] buffer)
+
+   tens-proto/PToTensorReader
+   (convertible-to-tensor-reader? [item]
+     (dtype-proto/convertible-to-reader? buffer))
+   (->tensor-reader [item options]
+     (let [{:keys [datatype unchecked?]} options]
+       (if (and (simple-dimensions? dimensions)
+                (instance? (resolve (tens-typecast/datatype->tensor-reader-type
+                                     datatype))
+                           buffer))
+         buffer
+         (let [sparse-data (make-tensor-base-sparse-reader buffer dimensions)
+               data-reader (dtype-proto/->reader buffer options)
+               indexes (dimensions->index-reader dimensions)
+               item-shape (dtype-proto/shape item)]
+           (case (casting/safe-flatten datatype)
+             :int8 (make-tensor-reader :int8 datatype item-shape
+                                       indexes data-reader sparse-data
+                                       item)
+             :int16 (make-tensor-reader :int16 datatype item-shape
+                                        indexes data-reader sparse-data
+                                        item)
+             :int32 (make-tensor-reader :int32 datatype item-shape
+                                        indexes data-reader sparse-data
+                                        item)
+             :int64 (make-tensor-reader :int64 datatype item-shape
+                                        indexes data-reader sparse-data
+                                        item)
+             :float32 (make-tensor-reader :float32 datatype item-shape
+                                          indexes data-reader sparse-data
+                                          item)
+             :float64 (make-tensor-reader :float64 datatype item-shape
+                                          indexes data-reader sparse-data
+                                          item)
+             :boolean (make-tensor-reader :boolean datatype item-shape
+                                          indexes data-reader sparse-data
+                                          item)
+             :object (make-tensor-reader :object datatype item-shape
+                                         indexes data-reader sparse-data
+                                         item))))))
+   Iterable
+   (iterator [item]
+     (.iterator ^Iterable (slice item 1)))
+   Object
+   (toString [item]
+     ;;Can't think of a better way of doing this.
+     ;;pprint requires the tensor methods *but* tostring requires
+     ;;pprint...
+     (tens-proto/print-tensor item)))
 
 
 (defn construct-tensor
   [buffer dimensions & [buffer-type]]
   (let [buffer-type (or buffer-type :tensor)]
-    (->
-     ;;Mother of all reify calls so we can override object methods also
-     (reify
-       dtype-proto/PDatatype
-       (get-datatype [item] (dtype-base/get-datatype buffer))
-
-
-       dtype-proto/PCountable
-       (ecount [item] (dims/ecount dimensions))
-
-
-       dtype-proto/PShape
-       (shape [m] (dims/shape dimensions))
-
-
-       dtype-proto/PPrototype
-       (from-prototype [m datatype shape]
-         (construct-tensor
-          (dtype-proto/from-prototype buffer datatype shape)
-          dimensions))
-
-
-       dtype-proto/PToNioBuffer
-       (convertible-to-nio-buffer? [item]
-         (dtype-proto/nio-convertible? buffer))
-       (->buffer-backing-store [item]
-         (when (simple-dimensions? dimensions)
-           (typecast/as-nio-buffer buffer)))
-
-
-       dtype-proto/PToList
-       (convertible-to-fastutil-list? [item]
-         (dtype-proto/list-convertible? buffer))
-       (->list-backing-store [item]
-         (when (simple-dimensions? dimensions)
-           (typecast/as-list buffer)))
-
-
-       jna/PToPtr
-       (is-jna-ptr-convertible? [item]
-         (jna/ptr-convertible? buffer))
-       (->ptr-backing-store [item]
-         (when (simple-dimensions? dimensions)
-           (jna/as-ptr buffer)))
-
-
-       dtype-proto/PToBufferDesc
-       (convertible-to-buffer-desc? [item]
-         (and (jna/ptr-convertible? buffer)
-              (dims-suitable-for-desc? dimensions)))
-       (->buffer-descriptor [item]
-         {:ptr (jna/as-ptr buffer)
-          :datatype (dtype/get-datatype buffer)
-          :shape (dtype/shape item)
-          :strides (mapv (partial * (casting/numeric-byte-width
-                                     (dtype/get-datatype buffer)))
-                         (:strides dimensions))})
-
-
-       dtype-proto/PToArray
-       (->sub-array [item]
-         (when (and (simple-dimensions? dimensions)
-                    (satisfies? dtype-proto/PToArray buffer))
-           (dtype-proto/->sub-array buffer)))
-
-       (->array-copy [item]
-         (if (and (simple-dimensions? dimensions)
-                  (satisfies? dtype-proto/PToArray buffer))
-           (dtype-proto/->array-copy buffer)
-           (dtype-proto/->array-copy (dtype-proto/->writer item {}))))
-
-
-       dtype-proto/PBuffer
-       (sub-buffer [item offset length]
-         (if (simple-dimensions? dimensions)
-           (dtype-proto/sub-buffer buffer offset length)
-           (throw (ex-info "Cannot sub-buffer tensors with complex addressing" {}))))
-
-
-       dtype-proto/PSetConstant
-       (set-constant! [item offset value elem-count]
-         (if (simple-dimensions? dimensions)
-           (dtype-proto/set-constant! buffer offset value elem-count)
-           (if (= :sparse (dtype/buffer-type buffer))
-             (dtype-proto/write-indexes! buffer
-                                         (-> (dimensions->index-reader dimensions)
-                                             (dtype-base/sub-buffer offset elem-count))
-                                         (sparse-reader/const-sparse-reader
-                                          value
-                                          (dtype-base/get-datatype item)
-                                          elem-count)
-                                         {:indexes-in-order?
-                                          (dims/access-increasing? dimensions)})
-             (dtype-proto/set-constant! (indexed-writer/make-indexed-writer
-                                         (dimensions->index-reader dimensions)
-                                         buffer
-                                         {})
-                                        offset value elem-count))))
-
-
-       dtype-proto/PWriteIndexes
-       (write-indexes! [item indexes values options]
-         (if (simple-dimensions? dimensions)
-           (dtype-proto/write-indexes! buffer indexes values options)
-           (dtype-proto/write-indexes! buffer (indexed-reader/make-indexed-reader
-                                               indexes
-                                               (dimensions->index-reader dimensions)
-                                               {:datatype :int32})
-                                       values options)))
-
-
-       dtype-proto/PToReader
-       (convertible-to-reader? [item] (dtype-proto/convertible-to-reader? buffer))
-       (->reader [item options]
-         (let [data-reader (dtype-proto/->reader buffer options)]
-           (if (simple-dimensions? dimensions)
-             data-reader
-             (tens-proto/->tensor-reader item options))))
-
-
-       dtype-proto/PToWriter
-       (convertible-to-writer? [item] (dtype-proto/convertible-to-writer? buffer))
-       (->writer [item options]
-         (let [data-writer (dtype-proto/->writer buffer options)]
-           (if (simple-dimensions? dimensions)
-             data-writer
-             (indexed-writer/make-indexed-writer (dimensions->index-reader dimensions)
-                                                 data-writer
-                                                 options))))
-
-
-       dtype-proto/PBufferType
-       (buffer-type [item]
-         (or buffer-type (dtype-proto/buffer-type buffer)))
-
-
-       ;;Tensors implement only a small subset of the sparse protocols
-       ;;For the full set, calling sparse-proto/as-sparse is your only option.
-       sparse-proto/PSparse
-       (index-seq [item]
-         (sparse-reader->index-seq (sparse-proto/as-sparse item) (dtype/shape item)))
-       (sparse-value [item]
-         (when-let [sparse-data (sparse-proto/as-sparse buffer)]
-           (sparse-proto/sparse-value buffer)))
-
-
-       sparse-proto/PToSparse
-       (convertible-to-sparse? [item]
-         (sparse-proto/sparse-convertible? buffer))
-       (->sparse [item]
-         (if (simple-dimensions? dimensions)
-           (sparse-proto/as-sparse buffer)
-           (make-tensor-base-sparse-reader buffer dimensions)))
-
-       tens-proto/PTensor
-       (is-tensor? [item] true)
-       (dimensions [item] dimensions)
-       (buffer [item] buffer)
-
-       tens-proto/PToTensorReader
-       (convertible-to-tensor-reader? [item]
-         (dtype-proto/convertible-to-reader? buffer))
-       (->tensor-reader [item options]
-         (let [{:keys [datatype unchecked?]} options]
-           (if (and (simple-dimensions? dimensions)
-                    (instance? (resolve (tens-typecast/datatype->tensor-reader-type
-                                         datatype))
-                               buffer))
-             buffer
-             (let [sparse-data (make-tensor-base-sparse-reader buffer dimensions)
-                   data-reader (dtype-proto/->reader buffer options)
-                   indexes (dimensions->index-reader dimensions)
-                   item-shape (dtype-proto/shape item)]
-               (case (casting/safe-flatten datatype)
-                 :int8 (make-tensor-reader :int8 datatype item-shape
-                                           indexes data-reader sparse-data
-                                           item)
-                 :int16 (make-tensor-reader :int16 datatype item-shape
-                                            indexes data-reader sparse-data
-                                            item)
-                 :int32 (make-tensor-reader :int32 datatype item-shape
-                                            indexes data-reader sparse-data
-                                            item)
-                 :int64 (make-tensor-reader :int64 datatype item-shape
-                                            indexes data-reader sparse-data
-                                            item)
-                 :float32 (make-tensor-reader :float32 datatype item-shape
-                                              indexes data-reader sparse-data
-                                              item)
-                 :float64 (make-tensor-reader :float64 datatype item-shape
-                                              indexes data-reader sparse-data
-                                              item)
-                 :boolean (make-tensor-reader :boolean datatype item-shape
-                                              indexes data-reader sparse-data
-                                              item)
-                 :object (make-tensor-reader :object datatype item-shape
-                                             indexes data-reader sparse-data
-                                             item))))))
-       Iterable
-       (iterator [item]
-         (.iterator ^Iterable (slice item 1)))
-       Object
-       (toString [item]
-         ;;Can't think of a better way of doing this.
-         ;;pprint requires the tensor methods *but* tostring requires
-         ;;pprint...
-         (with-out-str (println item)))
-       );;end reify
-     (with-meta {:type :tech.v2.tensor}))))
+    (Tensor. buffer dimensions buffer-type)))
 
 
 (defn tensor?

--- a/src/tech/v2/tensor/pprint.clj
+++ b/src/tech/v2/tensor/pprint.clj
@@ -6,7 +6,8 @@
             [tech.v2.datatype.unary-op :as unary]
             [tech.v2.tensor.impl :as tens-impl]
             [tech.v2.tensor.protocols :as tens-proto]
-            [tech.v2.datatype.reduce-op :as reduce-op])
+            [tech.v2.datatype.reduce-op :as reduce-op]
+            [tech.v2.datatype.pprint :as dtype-pprint])
   (:import [java.lang StringBuilder]
            [java.io Writer]
            [tech.v2.tensor.impl Tensor]))
@@ -16,19 +17,6 @@
 (set! *unchecked-math* true)
 
 (def ^String NL (System/getProperty "line.separator"))
-
-;; pretty-printing utilities for matrices
-(def ^:dynamic *number-format* "%.3f")
-
-(defn- format-num [x]
-  (if (integer? x)
-    (str x)
-    (format *number-format* (double x))))
-
-(defn- default-formatter [x]
-  (if (number? x)
-    (format-num x)
-    (str x)))
 
 (defn- column-lengths
   "Finds the longest string length of each column in an array of Strings."
@@ -96,7 +84,7 @@
   ([tens]
     (base-tensor->string tens nil))
   ([tens {:keys [prefix formatter]}]
-   (let [formatter (or formatter default-formatter)]
+   (let [formatter (or formatter dtype-pprint/format-object)]
      (if (number? tens)
        (formatter tens)
        (let [n-dims (count (dtype/shape tens))

--- a/src/tech/v2/tensor/pprint.clj
+++ b/src/tech/v2/tensor/pprint.clj
@@ -5,9 +5,11 @@
             [tech.v2.datatype.functional :as dtype-fn]
             [tech.v2.datatype.unary-op :as unary]
             [tech.v2.tensor.impl :as tens-impl]
+            [tech.v2.tensor.protocols :as tens-proto]
             [tech.v2.datatype.reduce-op :as reduce-op])
   (:import [java.lang StringBuilder]
-           [java.io Writer]))
+           [java.io Writer]
+           [tech.v2.tensor.impl Tensor]))
 
 
 (set! *warn-on-reflection* true)
@@ -117,6 +119,12 @@
           (base-tensor->string tens)))
 
 
-(defmethod print-method :tech.v2.tensor
+(defmethod print-method Tensor
   [tens w]
   (.write ^Writer w (tensor->string tens)))
+
+
+(extend-type Tensor
+  tens-proto/PTensorPrinter
+  (print-tensor [tensor]
+    (tensor->string tensor)))

--- a/src/tech/v2/tensor/protocols.clj
+++ b/src/tech/v2/tensor/protocols.clj
@@ -7,6 +7,10 @@
   (buffer [item]))
 
 
+(defprotocol PTensorPrinter
+  (print-tensor [item]))
+
+
 (defprotocol PToTensor
   (tensor-convertible? [item])
   (convert-to-tensor [item]))

--- a/test/tech/v2/datatype_test.clj
+++ b/test/tech/v2/datatype_test.clj
@@ -34,17 +34,22 @@
 
 (defn basic-copy
   [src-fn dest-fn src-dtype dst-dtype]
-  (let [ary (dtype/make-container src-fn src-dtype (range 10))
-        buf (dtype/make-container dest-fn dst-dtype 10)
-        retval (dtype/make-jvm-container :float64 10)]
-    ;;copy starting at position 2 of ary into position 4 of buf 4 elements
-    (dtype/copy! ary 2 buf 4 4)
-    (dtype/copy! buf 0 retval 0 10)
-    (is (= [0 0 0 0 2 3 4 5 0 0]
-           (mapv int (dtype/->vector retval)))
-        (pr-str {:src-fn src-fn :dest-fn dest-fn
-                 :src-dtype src-dtype :dst-dtype dst-dtype}))
-    (is (= 10 (dtype/ecount buf)))))
+  (try
+    (let [ary (dtype/make-container src-fn src-dtype (range 10))
+          buf (dtype/make-container dest-fn dst-dtype 10)
+          retval (dtype/make-jvm-container :float64 10)]
+      ;;copy starting at position 2 of ary into position 4 of buf 4 elements
+      (dtype/copy! ary 2 buf 4 4)
+      (dtype/copy! buf 0 retval 0 10)
+      (is (= [0 0 0 0 2 3 4 5 0 0]
+             (mapv int (dtype/->vector retval)))
+          (pr-str {:src-fn src-fn :dest-fn dest-fn
+                   :src-dtype src-dtype :dst-dtype dst-dtype}))
+      (is (= 10 (dtype/ecount buf))))
+    (catch Throwable e
+      (println {:src-fn src-fn :dest-fn dest-fn
+                :src-dtype src-dtype :dst-dtype dst-dtype})
+      (throw e))))
 
 
 (def create-functions [:typed-buffer :native-buffer :list :sparse])
@@ -291,3 +296,9 @@
   (is (thrown? Throwable (dfn/rem (double-array [1 2 3 4] 2))))
   (is (= [1 0 1 0]
          (dfn/rem [1 2 3 4] 2))))
+
+
+(deftest generic-lists
+  (is (= (vec (range 200 255))
+         (-> (dtype/make-container :list :uint8 (range 200 255))
+             dtype/->vector))))


### PR DESCRIPTION
Better repl integration and extensibility for Tensors and TypedBuffers.

*  Use of deftype as opposed to reify allows everything plus exposing external type for protocol implementations.
*  Use of deftype as opposed to defrecord for things that aren't logically maps of values greatly reduces confusion.
*  Pretty printing for typed buffers:
```clojure

tech.v2.datatype> (def test-container (make-container :native-buffer :uint8 (range 200 255)))
#'tech.v2.datatype/test-container
Aug 13, 2019 12:44:53 PM clojure.tools.logging$eval5849$fn__5852 invoke
INFO: Reference thread starting
tech.v2.datatype> test-container
#tech.v2.datatype.typed-buffer<java.nio.DirectByteBuffer,uint8>[55]
[200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, ...]
tech.v2.datatype> 
```