### PR TITLE
fix: reflection warnings on nio_buffer

### DIFF
--- a/src/tech/v2/datatype/nio_buffer.clj
+++ b/src/tech/v2/datatype/nio_buffer.clj
@@ -135,7 +135,7 @@
             (let [buf-pos# (.position item#)]
               (parallel-for/parallel-for
                idx# elem-count#
-               (buf-put item# (+ idx# offset#) buf-pos# value#))))))}
+               (buf-put item# (+ idx# offset#) buf-pos# (typecast/datatype->value ~datatype value#)))))))}
 
 
      dtype-proto/PBuffer

--- a/src/tech/v2/datatype/typecast.clj
+++ b/src/tech/v2/datatype/typecast.clj
@@ -639,3 +639,16 @@
   (if-let [jmap (as-java-map item)]
     jmap
     (throw (Exception. "Item is not a map: %s" item))))
+
+(defmacro datatype->value
+  "Convert an item into a known value type"
+  [datatype item]
+  (case (casting/safe-flatten datatype)
+    :int8    `^byte   ~item
+    :int16   `^short  ~item
+    :int32   `^int    ~item
+    :int64   `^long   ~item
+    :float32 `^float  ~item
+    :float64 `^double ~item
+    :boolean `^bool   ~item
+    :object  `~item))


### PR DESCRIPTION
Fixes reflection warnings on the nio_buffer namespace by adding a
`typecast/datatype->value` macro which performs the correct type
annotation based on the datatype keyword.