### PR TITLE
fix: reflection warnings on nio_buffer

### DIFF
--- a/src/tech/v2/datatype/nio_buffer.clj
+++ b/src/tech/v2/datatype/nio_buffer.clj
@@ -125,7 +125,7 @@
         (let [item# (typecast/datatype->buffer-cast-fn ~datatype item#)
               offset# (int offset#)
               elem-count# (int elem-count#)
-              value# (casting/cast value# ~datatype)
+              value# (casting/datatype->unchecked-cast-fn :unknown ~datatype value#)
               zero-val# (casting/cast 0 ~datatype)]
           (if (or (= value# zero-val#)
                   (= ~datatype :int8))


### PR DESCRIPTION
Fixes reflection warnings on the nio_buffer namespace by adding a
`typecast/datatype->value` macro which performs the correct type
annotation based on the datatype keyword.

I looked at the implementation of `casting/cast` and was a bit surprised that the compiler didn't manage to track the type through things.

Turns out annotating variables with type data using macros is a bit tricky, but this seems to take care of the reflection warnings.